### PR TITLE
Added login screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Open the `nap.config.ts` file and adjust it to your configuration.
 | `portals[].id` | The ID of the portal component specified in the NAP application |
 | `portals[].name` | The name of the portal that will show in the web interface |
 | `portals[].path` | The path of the address route where this component will be available |
+| `layout.showLogin` | Whether to show a login screen or connect automatically using the user and pass as set in config | 
 
 ## Usage
 

--- a/nap.config.ts
+++ b/nap.config.ts
@@ -11,11 +11,9 @@ export default {
       id: 'PortalComponent',
       name: 'Portal Component',
       path: 'portal-component',
-    },
-    {
-      id: 'PortalComponent2',
-      name: 'Portal Component 2',
-      path: 'portal-component-2',
-    },
+    }
   ],
+  layout: {
+    showLogin : true
+  }
 };

--- a/src/App.vue
+++ b/src/App.vue
@@ -9,6 +9,7 @@ import './styles/style.css';
 import './styles/table.css';
 import './styles/input.css';
 import './styles/button.css';
+import './styles/select.css';
 
 // Local Includes
 import AppMenu from './components/AppMenu.vue';

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,10 +15,12 @@ import PortalPage from './pages/PortalPage.vue';
 // Create NAPWebSocket connection
 const napWebSocket = new NAPWebSocket(napConfig.socket);
 
-// Open NAPWebSocket connection
-napWebSocket.open()
-  .then(() => console.log('NAPWebSocket opened successfully'))
-  .catch(error => console.error(`NAPWebSocket failed to open: ${error.message}`));
+// Open NAPWebSocket connection if we don't open the connection using a login 
+if(!napConfig.layout.showLogin){
+  napWebSocket.open()
+    .then(() => console.log('NAPWebSocket opened successfully'))
+    .catch(error => console.error(`NAPWebSocket failed to open: ${error.message}`));
+}
 
 // Create Vue Router
 const router = createRouter({
@@ -27,6 +29,7 @@ const router = createRouter({
     {
       path: '/',
       component: HomePage,
+      props: { napWebSocket }
     },
     {
       path: '/:portal',

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -1,5 +1,112 @@
+<script setup lang="ts">
+// External Includes
+import { reactive } from 'vue'
+import { ref } from 'vue';
+import {
+  NAPWebSocket,
+  NAPWebSocketEvent,
+} from 'nap-portal';
+
+// Local Includes
+import napConfig from '../../nap.config';
+
+// Define props
+const props = defineProps<{
+  napWebSocket: NAPWebSocket,
+}>();
+
+// Create reactive connected variable
+const connected = ref(props.napWebSocket.isOpen);
+
+// Create reactive elements to show error message
+const showError = ref(false)
+const errorMessage = ref("")
+
+// Do we show login or regular homepage ?
+const showLoginPage = ref(napConfig.layout.showLogin)
+
+// Subscribe to WebSocket open event
+props.napWebSocket.addEventListener(NAPWebSocketEvent.Open, {
+  handleEvent: (event: CustomEvent) => connected.value = true,
+});
+
+// Subscribe to WebSocket close event
+props.napWebSocket.addEventListener(NAPWebSocketEvent.Close, {
+  handleEvent: (event: CustomEvent) => connected.value = false,
+});
+
+// Create reactive form
+const form = reactive({
+    username: napConfig.socket.user,
+    password: napConfig.socket.pass
+});
+
+// On submit callback function
+const onSubmit = () => {
+  // Close previous connection
+  if(props.napWebSocket?.isOpen)
+    props.napWebSocket?.close();
+
+  // Set user and pass from form
+  props.napWebSocket?.setUserAndPass(form.username, form.password);
+
+  // Try to open socket
+  props.napWebSocket?.open()
+    .then(() => {
+      console.log('NAPWebSocket opened successfully');
+      showError.value = false;
+    })
+    .catch(error => { 
+      console.error(`NAPWebSocket failed to open: ${error.message}`);
+      showError.value = true;
+      errorMessage.value = error.message;
+    });
+};
+</script>
+
 <template>
-  <div>
-    Welcome to your NAP dashboard!
-  </div>
+    <div v-if="connected || showLoginPage === false">
+        Welcome to your NAP dashboard!
+    </div>
+    <div v-else>
+        <form @submit.prevent="onSubmit" name="login-form" >
+      <div class="mb-3">
+        <label for="username">Username: </label>
+        <input 
+        v-model="form.username"
+        class="form-control"
+        placeholder="username"
+        required/>
+      </div>
+      <div class="mb-3">
+        <label for="password">Password: </label>
+        <input 
+        v-model="form.password"
+        class="form-control"
+        type="password"
+        placeholder="password"
+        required>
+      </div>
+      <button class="btn btn-outline-dark" type="submit">
+        Login
+      </button>
+      <div v-if="showError">
+        <span class="status" :class="{ connected }">
+          {{ errorMessage }}
+        </span>
+      </div><div v-else></div>
+    </form>
+
+    </div>
 </template>
+
+<style scoped>
+.status {
+  color: var(--red);
+  line-height: 2.5em;
+  font-size: small;
+}
+.status.connected {
+  color: var(--green-medium);
+}
+</style>

--- a/src/styles/select.css
+++ b/src/styles/select.css
@@ -1,0 +1,20 @@
+select {
+    display: block;
+    border: none;
+    cursor: pointer;
+    text-align: center;
+    margin: 0.25em 0;
+    padding: 0 1em;
+    line-height: 2.5em;
+    color: var(--white);
+    background-color: var(--gray-medium);
+  }
+  
+  select:hover {
+    background-color: var(--gray-light);
+  }
+  
+  select:active {
+    background-color: var(--blue);
+  }
+  


### PR DESCRIPTION
- HomePage can show a login window
- config has a new property called 'layout' that contains a property called 'showLogin' that prevents the app from automatically opening the websocket but displays a login screen instead on the homepage
- added style for select (dropdown menus)

To use this, link against the 'dropdown' branch of the [nap-portal](https://github.com/napframework/nap-portal/tree/dropdown) node